### PR TITLE
ES6 syntax fixed for UglifyJS

### DIFF
--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -22,12 +22,12 @@ var Filter = (function() {
     this.replaceRegex = options.replaceRegex || /\w/g;
 
     // convert list to lower case
-    for (let i = 0; i < this.list.length; i++) {
+    for (var i = 0; i < this.list.length; i++) {
       this.list[i] = this.list[i].toLowerCase();
     }
 
     // remove duplicates
-    let wordSet = new Set(this.list);
+    var wordSet = new Set(this.list);
     this.list = Array.from(wordSet);
 
     this.list.sort();
@@ -52,7 +52,7 @@ var Filter = (function() {
    * @param {string} word - String to evaluate for profanity.
    */
   Filter.prototype.isProfaneLike = function profaneLike(word) {
-    let isProfane = false;
+    var isProfane = false;
 
     if (!!~this.exclude.indexOf(word)) {
       isProfane = false;


### PR DESCRIPTION
Hello, I had a problem when I tried to run Webpack in production mode due to UglifyJS does not support ES6 syntax, so the solution only was change the key word "let" by "var". Could you incorporate this change to the repo or do it by yourself if you want?. Thank you very much!