### PR TITLE
Add option to override blacklist with custom list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ results
 npm-debug.log
 node_modules
 .idea
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ legitimate words like "japanese" or "assimilate".  bad-words-relaxed is forked f
 
     //or
 
-    var filter = new Filter({ list: ['some', 'bad', 'word'] }); 
+    var filter = new Filter({ addList: ['some', 'bad', 'word'] }); 
 
     filter.clean("some bad word!") //**** *** ****!
+
+### Instantiate with custom blacklist
+
+    var filter = new Filter({list: ['some', 'bad', 'word']}); 
+
+    filter.clean("some bad word fuck!") //**** *** **** fuck!
 
 ### Instantiate with an empty list
 

--- a/lib/badwords.js
+++ b/lib/badwords.js
@@ -8,6 +8,7 @@ var Filter = (function() {
    * @param {object} options - Filter instance options
    * @param {boolean} options.emptyList - Instantiate filter with no blacklist
    * @param {array} options.list - Instantiate filter with custom list
+   * @param {array} options.addList - Add custom list to blacklist.
    * @param {string} options.placeHolder - Character used to replace profane words.
    * @param {string} options.regex - Regular expression used to sanitize words before comparing them to blacklist.
    * @param {string} options.replaceRegex - Regular expression used to replace profane words with placeHolder.
@@ -15,7 +16,7 @@ var Filter = (function() {
    */
   function Filter(options) {
     options = options || {};
-    this.list = options.emptyList && [] || Array.prototype.concat.apply(relaxedList, [ options.list || []]);
+    this.list = options.emptyList && [] || options.list || Array.prototype.concat.apply(relaxedList, [ options.addList || []]);
     this.exclude = options.exclude || [];
     this.placeHolder = options.placeHolder || '*';
     this.regex = options.regex || /[^a-zA-z0-9|\$|\@]|\^/g;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "better-assert": "1.0.0",
     "documentation": "^5.3.3",
-    "mocha": "1.14.0"
+    "mocha": "^5.2.0"
   },
   "author": "Jared Sprague",
   "license": "MIT"

--- a/test/isProfane.js
+++ b/test/isProfane.js
@@ -47,5 +47,19 @@ describe('filter', function(){
 			});
 			assert(filter.isProfane('test'));
 		});
+
+		it('Should only detect words from custom list', function() {
+			let filter = new Filter({
+				list: ['test']
+			});
+			assert(filter.isProfane('test') && !filter.isProfane('fuck'));
+		});
+
+		it('Should detect words from custom list and default list', function() {
+			let filter = new Filter({
+				addList: ['test']
+			});
+			assert(filter.isProfane('test') && filter.isProfane('fuck'));
+		});
 	});
 });


### PR DESCRIPTION
The previous `list` parameter would not override the default blacklist, it would just add words to it instead. 
This change fixes `list` parameter and also adds an `addList` option so users can also add their own lists to the default one.